### PR TITLE
Update vendor dependencies

### DIFF
--- a/vendordeps/PathplannerLib-2025.2.5.json
+++ b/vendordeps/PathplannerLib-2025.2.5.json
@@ -1,7 +1,7 @@
 {
-    "fileName": "PathplannerLib-2025.2.4.json",
+    "fileName": "PathplannerLib-2025.2.5.json",
     "name": "PathplannerLib",
-    "version": "2025.2.4",
+    "version": "2025.2.5",
     "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
     "frcYear": "2025",
     "mavenUrls": [
@@ -12,7 +12,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-java",
-            "version": "2025.2.4"
+            "version": "2025.2.5"
         }
     ],
     "jniDependencies": [],
@@ -20,7 +20,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-cpp",
-            "version": "2025.2.4",
+            "version": "2025.2.5",
             "libName": "PathplannerLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,

--- a/vendordeps/REVLib.json
+++ b/vendordeps/REVLib.json
@@ -1,7 +1,7 @@
 {
-    "fileName": "REVLib-2025.0.2.json",
+    "fileName": "REVLib.json",
     "name": "REVLib",
-    "version": "2025.0.2",
+    "version": "2025.0.3",
     "frcYear": "2025",
     "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-java",
-            "version": "2025.0.2"
+            "version": "2025.0.3"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2025.0.2",
+            "version": "2025.0.3",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [
@@ -36,7 +36,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-cpp",
-            "version": "2025.0.2",
+            "version": "2025.0.3",
             "libName": "REVLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -53,7 +53,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2025.0.2",
+            "version": "2025.0.3",
             "libName": "REVLibDriver",
             "headerClassifier": "headers",
             "sharedLibrary": false,


### PR DESCRIPTION
Update library releases:

* Pathplanner: https://github.com/mjansen4857/pathplanner/compare/v2025.2.4...v2025.2.5
* REVLib: https://github.com/REVrobotics/REV-Software-Binaries/releases/tag/revlib-2025.0.3